### PR TITLE
Add date ranges support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "github-activity-summarizer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "zed_extension_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "github-activity-summarizer"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The extension can be configured in your Zed project settings:
       "repositories": [],                                 // Optional: specific repositories to include (defaults to all)
       "query_extra": "",                                  // Optional: additional GitHub search query filters (defaults to none)
       "from_date": "1 week ago",                           // Optional: time range to fetch activity from (defaults to 7 days ago)
+      "to_date": "",                                       // Optional: time range ending at the current date if not set.
       "auth_type": "all"                                  // Optional: authentication type (defaults to "all")
     }
   }
@@ -65,6 +66,12 @@ Valid authentication types are:
 If no options are provided, the extension will fetch activity from all repositories you have access to, since last week (7 days ago).
 
 `repositories` is a list of `owner/repo` to include in the search query.
+
+`from_date` is a string representing the start date of the time range to fetch activity from. It can be a date in the format `YYYY-MM-DD` or a relative date like `1 week ago`.
+
+`to_date` is a string representing the end date of the time range to fetch activity from. It can be a date in the format `YYYY-MM-DD` or a relative date like `1 week ago`.
+
+Note that `to_date` must be after `from_date`, because time warping isn't currently supported.
 
 The `github-gas-server` binary is downloaded automatically from the GitHub repository. If you want to specify a custom path, you can do so by setting the `path` option in the `command` section:
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "github-activity-summarizer"
 name = "GitHub Activity Summarizer"
-version = "0.3.0"
+version = "0.4.0"
 schema_version = 1
 authors = ["Sergio Rubio rubiojr@rbel.co"]
 description = "Summarizes your GitHub activity over a period of time"

--- a/server/internal/mcpserver/mcpserver.go
+++ b/server/internal/mcpserver/mcpserver.go
@@ -54,6 +54,11 @@ func New() (*MCPServer, error) {
 		opts = append(opts, summarizer.WithFromDate(fromDate))
 	}
 
+	toDate := os.Getenv("GITHUB_GAS_TO_DATE")
+	if toDate != "" {
+		opts = append(opts, summarizer.WithToDate(toDate))
+	}
+
 	author := os.Getenv("GITHUB_GAS_AUTHOR")
 	if author != "" {
 		opts = append(opts, summarizer.WithAuthor(author))


### PR DESCRIPTION
Adds a new optional extension setting to_date, to set the end date of the GitHub search query.

When set, the search query uses the date range <from_date>..<to_date> for the activity period.

If not set, the end date is set to today.

Fixes https://github.com/rubiojr/gas/issues/3