### PR TITLE
Windows support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "zed_extension_api"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ef88a8e5aeff67b0996b1795d56338f04c02de95f1f147577944aa37b801d6"
+checksum = "0729d50b4ca0a7e28e590bbe32e3ca0194d97ef654961451a424c661a366fca0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ path = "src/lib.rs"
 [dependencies]
 serde = "1.0"
 schemars = "0.8"
-zed_extension_api = "0.5.0"
+zed_extension_api = "0.7.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "github-activity-summarizer"
 name = "GitHub Activity Summarizer"
-version = "0.5.1"
+version = "0.5.2"
 schema_version = 1
 authors = ["Sergio Rubio rubiojr@rbel.co"]
 description = "Summarizes your GitHub activity over a period of time"


### PR DESCRIPTION
This PR bumps the `zed_extension_api` to 0.7, to make `std::env::current_dir` work correctly on Windows. I've also bumped the extension version so that we'll be ready to publish a new version.